### PR TITLE
FileNotFoundError raised when the settings file is not created

### DIFF
--- a/python/custom_brush_resize/utils.py
+++ b/python/custom_brush_resize/utils.py
@@ -67,8 +67,9 @@ def write_to_json(file_path, data):
 def read_from_json(file_path):
     """Read data from given json file."""
     data = {}
-    with open(file_path) as _file:
-        data = json.loads(_file.read())
+    if os.path.exists(file_path):
+        with open(file_path) as _file:
+            data = json.loads(_file.read())
     return data
 
 


### PR DESCRIPTION
Patch to resolve a FileNotFoundError when the user settings file has not yet been created.